### PR TITLE
Fix typo: "decoeder" → "decoder" in GPT model docstring

### DIFF
--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -253,7 +253,7 @@ class GPTModel(LanguageModule):
         loss_mask: Optional[Tensor] = None,
     ) -> Tensor:
         """Forward function of the GPT Model This function passes the input tensors
-        through the embedding layer, and then the decoeder and finally into the post
+        through the embedding layer, and then the decoder and finally into the post
         processing layer (optional).
 
         It either returns the Loss values if labels are given  or the final hidden units


### PR DESCRIPTION
This PR corrects a typo in the docstring of the `forward` function in `gpt_model.py`. Changed "decoeder" to "decoder".